### PR TITLE
Ad hdf5 single

### DIFF
--- a/startup/22-rixscam.py
+++ b/startup/22-rixscam.py
@@ -298,6 +298,15 @@ class RIXSCamHDF5PluginForXIP(HDF5Plugin, FileStoreHDF5SingleIterativeWrite):
     '''This modifies the `array_size` attribute so that the second value is
     'unknown'.
     '''
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Update the filestore_spec name
+        self.filestore_spec = 'AD_HDF5_SINGLE_XIP'
+
+    # Add some parameters required to retrieve the data as a pandas dataframe
+    key = '/entry/data/data'
+    column_names = ['x', 'y', 'x_eta', 'y_eta', 'y_eta_iso', 'sum_regions',
+                    'XIP mode']
 
     # Override the write_path_template code in FileStoreBase because is
     # assumes UNIX, not Windows, and adds a trailing forward slash.
@@ -316,6 +325,20 @@ class RIXSCamHDF5PluginForXIP(HDF5Plugin, FileStoreHDF5SingleIterativeWrite):
         if self.centroid:
             self.hdf2.generate_datum('rixscam_centroids', ttime.time(), {})
         return self._status
+
+    # write a new stage method that adds `column_names` and `key` to
+    # resource_kwargs.
+    def stage(self):
+        super().stage()
+        # this over-rides the behavior is the base stage
+        self._fn = self._fp
+
+        resource_kwargs = {'template': self.file_template.get(),
+                           'filename': self.file_name.get(),
+                           'key': self.key,
+                           'column_names': self.column_names,
+                           'frame_per_point': self.get_frames_per_point()}
+        self._generate_resource(resource_kwargs)
 
 
 class RIXSSingleTrigger(SingleTrigger):

--- a/startup/22-rixscam.py
+++ b/startup/22-rixscam.py
@@ -302,8 +302,8 @@ class RIXSCamHDF5PluginForXIP(HDF5Plugin, FileStoreHDF5SingleIterativeWrite):
 
     # Add some parameters required to retrieve the data as a pandas dataframe
     key = '/entry/data/data'
-    column_names = ['x', 'y', 'x_eta', 'y_eta', 'y_eta_iso', 'sum_regions',
-                    'XIP mode']
+    column_names = ('x', 'y', 'x_eta', 'y_eta', 'y_eta_iso', 'sum_regions',
+                    'XIP mode')
 
     # Override the write_path_template code in FileStoreBase because is
     # assumes UNIX, not Windows, and adds a trailing forward slash.


### PR DESCRIPTION
This PR is used to update the HDF5 plugin for the XIP plugin so that it includes `column_names` and `key` in the `resource_kwargs` as required by the new `handler`