### PR TITLE
Enable Azure Pipelines integration

### DIFF
--- a/.ci/bl-specific.sh
+++ b/.ci/bl-specific.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# cp -v <...> ~/.ipython/profile_${TEST_PROFILE}/
+
+conda install -y -c ${CONDA_CHANNEL_NAME} 02-id-six-collection

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,12 @@
+resources:
+  repositories:
+    - repository: templates
+      type: github
+      name: NSLS-II/profile-collection-ci
+      # ref: refs/heads/<branch-name>  # for future testings on a branch of NSLS-II/profile-collection-ci
+      endpoint: github
+
+jobs:
+- template: azure-linux.yml@templates  # Template reference
+  parameters:
+    beamline_acronym: SIX


### PR DESCRIPTION
Uses https://github.com/NSLS-II/profile-collection-ci.

Currently fails on caproto client (https://dev.azure.com/nsls2/profile_collections/_build/results?buildId=63):
```py
CaprotoTimeoutError‌: &lt;PV name=&#x27;XF:02ID1-ES{RIXSCam}:HDF1:PluginType_RBV&#x27; priority=0 (searching....)&gt; could not connect within 1.0-second timeout.‌
Exception in thread retry:
Traceback (most recent call last):
  File "/home/vsts/mc/envs/collection-2019C3.0.1/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/home/vsts/mc/envs/collection-2019C3.0.1/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/home/vsts/mc/envs/collection-2019C3.0.1/lib/python3.6/site-packages/caproto/threading/client.py", line 858, in _retry_unanswered_searches
    SEARCH_MAX_DATAGRAM_BYTES - len(version_req)):
  File "/home/vsts/mc/envs/collection-2019C3.0.1/lib/python3.6/site-packages/caproto/_utils.py", line 772, in batch_requests
    for command in request_iter:
  File "/home/vsts/mc/envs/collection-2019C3.0.1/lib/python3.6/site-packages/caproto/threading/client.py", line 830, in _construct_search_requests
    ca.DEFAULT_PROTOCOL_VERSION)
  File "/home/vsts/mc/envs/collection-2019C3.0.1/lib/python3.6/site-packages/caproto/_commands.py", line 607, in __init__
    ''.format(MAX_RECORD_LENGTH, name, _len))
caproto._utils.CaprotoValueError: EPICS 3.14 imposes a 59-character limit on record names. The record 'XF:02ID1-ES{RIXSCam}:XIP1:HR_ISOLINEAR_CALIBRATION_THRESHOLD' is 60 characters.
```

xref https://github.com/NSLS-II/profile-collection-ci/issues/2