### PR TITLE
Use lustre storage; create dir tree automatically by AD

### DIFF
--- a/startup/21-areadetector.py
+++ b/startup/21-areadetector.py
@@ -16,17 +16,9 @@ start_time=time.monotonic()
 class HDF5PluginWithFileStore(HDF5Plugin_V22, FileStoreHDF5IterativeWrite):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._old_create_directory = ""
-
-    def stage(self, *args, **kwargs):
-        self._old_create_directory = self.create_directory.get(as_string=True)
         # In CSS help: "N < 0: Up to abs(N) new directory levels will be created"
-        self.create_directory.put(-3)
-        super().stage(*args, **kwargs)
-
-    def unstage(self, *args, **kwargs):
-        super().unstage(*args, **kwargs)
-        self.create_directory.put(self._old_create_directory)
+        self.stage_sigs.update({"create_directory": -3})
+        self.stage_sigs.move_to_end("create_directory", last=False)
 
     def get_frames_per_point(self):
         return self.parent.cam.num_images.get()  # HACK fixed from =1 to this self.

--- a/startup/21-areadetector.py
+++ b/startup/21-areadetector.py
@@ -16,7 +16,7 @@ start_time=time.monotonic()
 class HDF5PluginWithFileStore(HDF5Plugin_V22, FileStoreHDF5IterativeWrite):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # In CSS help: "N < 0: Uop to abs(N) new directory levels will be created"
+        # In CSS help: "N < 0: Up to abs(N) new directory levels will be created"
         self.stage_sigs.update({"create_directory": -3})
 
     def stage(self, *args, **kwargs):

--- a/startup/21-areadetector.py
+++ b/startup/21-areadetector.py
@@ -16,11 +16,11 @@ start_time=time.monotonic()
 class HDF5PluginWithFileStore(HDF5Plugin_V22, FileStoreHDF5IterativeWrite):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._old_create_directory = ''
+        self._old_create_directory = ""
 
     def stage(self, *args, **kwargs):
         self._old_create_directory = self.create_directory.get(as_string=True)
-        # in css help: "n < 0: up to abs(n) new directory levels will be created"
+        # In CSS help: "N < 0: Up to abs(N) new directory levels will be created"
         self.create_directory.put(-3)
         super().stage(*args, **kwargs)
 


### PR DESCRIPTION
In this update I've used the [`HDF5Plugin_V22`](https://github.com/bluesky/ophyd/blob/047eab1ffb95c6c752e68c89e52fb8d20bf6c021/ophyd/areadetector/plugins.py#L1141-L1142) plugin, which defines [`FilePlugin_V22`](https://github.com/bluesky/ophyd/blob/047eab1ffb95c6c752e68c89e52fb8d20bf6c021/ophyd/areadetector/plugins.py#L1071-L1076), that has the `create_directory` component. The value for that component is set to `-3` via the `stage_sigs`, so that 3 levels of directories are created (`%Y/%m/%d`).

Here is the help from CSS on that feature, for future reference:
![image](https://user-images.githubusercontent.com/13209176/122834920-88296c00-d2bd-11eb-9572-bd07d9bf3683.png)

The storage location for the hdf5 files is set to be the Lustre mount.
