### PR TITLE
FIX: deadbands redundantly finishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ db/
 *~
 static/
 backupstartup/
+
+# IDEs
+.idea/
+.vscode/

--- a/startup/04-epu.py
+++ b/startup/04-epu.py
@@ -129,7 +129,11 @@ class UgapPositioner(DeadbandMixin, PVPositioner):
     safety_device_fail = Cpt(EpicsSignalRO, '}Sts:Safety-Sts', string=True)
     emergency_open_gap = Cpt(EpicsSignalRO, '}Sts:OpenGapCmd-Sts', string=True)
     # TODO subscribe kill switch prressed and stop motion
-    
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.tolerance.put(0.0005)
+
 
 class UphasePositioner(DeadbandMixin, PVPositioner):
     readback = Cpt(EpicsSignalRO, '-Ax:Phase}Mtr.RBV')
@@ -145,7 +149,10 @@ class UphasePositioner(DeadbandMixin, PVPositioner):
     safety_device_fail = Cpt(EpicsSignalRO, '}Sts:Safety-Sts', string=True)
     emergency_open_gap = Cpt(EpicsSignalRO, '}Sts:OpenGapCmd-Sts', string=True)
     # TODO subscribe kill switch prressed and stop motion
-    
+
+    def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.tolerance.put(0.0005)
 
 
 class EPU(Device):


### PR DESCRIPTION
Previous implementations of deadband would callback and finish for small movements after finish had already been called on the status. This would lead to gigabytes of logs of the form:

```python
[E 2023-07-31 12:29:29,029.029 ophyd.objects  ophydobj:465] Subscription value callback exception (EpicsSignalRO(read_pv='SR:C02-ID:G1A{EPU:1-Ax:Phase}Mtr.RBV', name='epu1_phase_readback', parent='epu1_phase', value=-0.0001, timestamp=1690820969.01945, auto_monitor=False, string=False))
Traceback (most recent call last):
  File "/nsls2/conda/envs/2022-2.1-py39-tiled/lib/python3.9/site-packages/ophyd/ophydobj.py", line 462, in inner
    cb(*args, **kwargs)
  File "/nsls2/data/six/shared/config/bluesky/profile_collection/startup/04-epu.py", line 27, in rbv_callback
    sts._finished()
  File "/nsls2/conda/envs/2022-2.1-py39-tiled/lib/python3.9/site-packages/ophyd/status.py", line 353, in _finished
    self.set_finished()
  File "/nsls2/conda/envs/2022-2.1-py39-tiled/lib/python3.9/site-packages/ophyd/status.py", line 319, in set_finished
    raise InvalidState(
ophyd.utils.errors.InvalidState: Either set_finished() or set_exception() has already been called on MoveStatus(done=True, pos=epu1_phase, elapsed=14.4, success=True, settle_time=0.0)
```

This borrows from Jamie's efforts at SST. I would like to test this, then put a ticket in to move it to the nslsii package and import it directly. 