### PR TITLE
Proper Keithley Ophyd device

### DIFF
--- a/startup/96-keithley.py
+++ b/startup/96-keithley.py
@@ -1,66 +1,138 @@
-from ophyd import EpicsSignal
+from ophyd import (
+    Device,
+    Component as Cpt,
+    EpicsSignal,
+    EpicsSignalRO,
+    Kind,
+    PVPositioner,
+    PVPositionerPC,
+)
 
 
-voltage_dc_1A = EpicsSignal('XF:02IDD{K2636B:1-ChA}SP-VLvl', name = 'voltage_dc_1A')
-current_dc_1A = EpicsSignal('XF:02IDD{K2636B:1-ChA}SP-ILvl', name='current_dc_1A')
-voltage_dc_sp_rbk_1A = EpicsSignal('XF:02IDD{K2636B:1-ChA}RB-VLvl', name = 'voltage_dc_sp_rbk_1A')
-current_dc_sp_rbk_1A = EpicsSignal('XF:02IDD{K2636B:1-ChA}RB-ILvl', name='current_dc_sp_rbk_1A')
-keithley_output_1A = EpicsSignal('XF:02IDD{K2636B:1-ChA}Cmd:Out-Ena', name = 'keithley_output_1A')
-current_rbk_1A = EpicsSignal('XF:02IDD{K2636B:1-ChA}RB-MeasI', name = 'current_rbk_1A')
-voltage_rbk_1A = EpicsSignal('XF:02IDD{K2636B:1-ChA}RB-MeasV',name='voltage_rbk_1A')
-resistance_rbk_1A = EpicsSignal('XF:02IDD{K2636B:1-ChA}RB-MeasR',name='resistance_rbk_1A')
-current_pulse_1A = EpicsSignal('XF:02IDD{K2636B:1-ChA}PIMV-CurrLevl', name = 'current_pulse_1A')
-meaure_mode_1A = EpicsSignal('XF:02IDD{K2636B:1-ChA}Meas-Sel', name = 'measure_mode_1A')
-time_pulse_1A = EpicsSignal('XF:02IDD{K2636B:1-ChA}PIMV-TOn', name = 'time_pulse_1A')
-interval_pulse_1A = EpicsSignal('XF:02IDD{K2636B:1-ChA}Cmd-Pulse.SCAN', name = 'interval_pulse_1A')
-voltage_pulse_rbk_1A = EpicsSignal('XF:02IDD{K2636B:1-ChA}Prev-Buf', name = 'voltage_pulse_rbk_1A')
+class Keithley2600BVoltage(PVPositionerPC):
+    """PVPositioner for direct Keithley 2600B voltage control (immediate)."""
+
+    setpoint = Cpt(EpicsSignal, 'SP-VLvl')
+    readback = Cpt(EpicsSignalRO, 'RB-VLvl')
 
 
-voltage_dc_1B = EpicsSignal('XF:02IDD{K2636B:1-ChB}SP-VLvl', name = 'voltage_dc_1B')
-current_dc_1B = EpicsSignal('XF:02IDD{K2636B:1-ChB}SP-ILvl', name='current_dc_1B')
-voltage_dc_sp_rbk_1B = EpicsSignal('XF:02IDD{K2636B:1-ChB}RB-VLvl', name = 'voltage_dc_sp_rbk_1B')
-current_dc_sp_rbk_1B = EpicsSignal('XF:02IDD{K2636B:1-ChB}RB-ILvl', name='current_dc_sp_rbk_1B')
-keithley_output_1B = EpicsSignal('XF:02IDD{K2636B:1-ChB}Cmd:Out-Ena', name = 'keithley_output_1B')
-current_rbk_1B = EpicsSignal('XF:02IDD{K2636B:1-ChB}RB-MeasI', name = 'current_rbk_1B')
-voltage_rbk_1B = EpicsSignal('XF:02IDD{K2636B:1-ChB}RB-MeasV',name='voltage_rbk_1B')
-resistance_rbk_1B = EpicsSignal('XF:02IDD{K2636B:1-ChB}RB-MeasR',name='resistance_rbk_1B')
-meaure_mode_1B = EpicsSignal('XF:02IDD{K2636B:1-ChB}Meas-Sel', name = 'measure_mode_1B') ########## FIX THIS #########
-current_pulse_1B = EpicsSignal('XF:02IDD{K2636B:1-ChB}PIMV-CurrLevl', name = 'current_pulse_1B')
-time_pulse_1B = EpicsSignal('XF:02IDD{K2636B:1-ChB}PIMV-TOn', name = 'time_pulse_1B')
-interval_pulse_1B = EpicsSignal('XF:02IDD{K2636B:1-ChB}Cmd-Pulse.SCAN', name = 'interval_pulse_1B')
-voltage_pulse_rbk_1B = EpicsSignal('XF:02IDD{K2636B:1-ChB}Prev-Buf', name = 'voltage_pulse_rbk_1B')
+class Keithley2600BCurrent(PVPositionerPC):
+    """PVPositioner for direct Keithley 2600B current control (immediate)."""
+
+    setpoint = Cpt(EpicsSignal, 'SP-ILvl')
+    readback = Cpt(EpicsSignalRO, 'RB-ILvl')
 
 
+class Keithley2600BVoltageRamped(PVPositioner):
+    """PVPositioner for ramped Keithley 2600B voltage control (speed-controlled)."""
 
-voltage_dc_2A = EpicsSignal('XF:02IDD{K2636B:2-ChA}SP-VLvl', name = 'voltage_dc_2A')
-current_dc_2A = EpicsSignal('XF:02IDD{K2636B:2-ChA}SP-ILvl', name='current_dc_2A')
-voltage_dc_sp_rbk_2A = EpicsSignal('XF:02IDD{K2636B:2-ChA}RB-VLvl', name = 'voltage_dc_sp_rbk_2A')
-current_dc_sp_rbk_2A = EpicsSignal('XF:02IDD{K2636B:2-ChA}RB-ILvl', name='current_dc_sp_rbk_2A')
-keithley_output_2A = EpicsSignal('XF:02IDD{K2636B:2-ChA}Cmd:Out-Ena', name = 'keithley_output_2A')
-current_rbk_2A = EpicsSignal('XF:02IDD{K2636B:2-ChA}RB-MeasI', name = 'current_rbk_2A')
-voltage_rbk_2A = EpicsSignal('XF:02IDD{K2636B:2-ChA}RB-MeasV',name='voltage_rbk_2A')
-resistance_rbk_2A = EpicsSignal('XF:02IDD{K2636B:2-ChA}RB-MeasR',name='resistance_rbk_2A')
-current_pulse_2A = EpicsSignal('XF:02IDD{K2636B:2-ChA}PIMV-CurrLevl', name = 'current_pulse_2A')
-meaure_mode_2A = EpicsSignal('XF:02IDD{K2636B:2-ChA}Meas-Sel', name = 'measure_mode_2A')
-time_pulse_2A = EpicsSignal('XF:02IDD{K2636B:2-ChA}PIMV-TOn', name = 'time_pulse_2A')
-interval_pulse_2A = EpicsSignal('XF:02IDD{K2636B:2-ChA}Cmd-Pulse.SCAN', name = 'interval_pulse_2A')
-voltage_pulse_rbk_2A = EpicsSignal('XF:02IDD{K2636B:2-ChA}Prev-Buf', name = 'voltage_pulse_rbk_2A')
+    setpoint = Cpt(EpicsSignal, 'Val:SP-E_u')
+    readback = Cpt(EpicsSignalRO, 'RB-VLvl')
+    done = Cpt(EpicsSignalRO, 'DMOV-E')
+    done_value = 1
 
 
-voltage_dc_2B = EpicsSignal('XF:02IDD{K2636B:2-ChB}SP-VLvl', name = 'voltage_dc_2B')
-current_dc_2B = EpicsSignal('XF:02IDD{K2636B:2-ChB}SP-ILvl', name='current_dc_2B')
-voltage_dc_sp_rbk_2B = EpicsSignal('XF:02IDD{K2636B:2-ChB}RB-VLvl', name = 'voltage_dc_sp_rbk_2B')
-current_dc_sp_rbk_2B = EpicsSignal('XF:02IDD{K2636B:2-ChB}RB-ILvl', name='current_dc_sp_rbk_2B')
-keithley_output_2B = EpicsSignal('XF:02IDD{K2636B:2-ChB}Cmd:Out-Ena', name = 'keithley_output_2B')
-current_rbk_2B = EpicsSignal('XF:02IDD{K2636B:2-ChB}RB-MeasI', name = 'current_rbk_2B')
-voltage_rbk_2B = EpicsSignal('XF:02IDD{K2636B:2-ChB}RB-MeasV',name='voltage_rbk_2B')
-resistance_rbk_2B = EpicsSignal('XF:02IDD{K2636B:2-ChB}RB-MeasR',name='resistance_rbk_2B')
-meaure_mode_2B = EpicsSignal('XF:02IDD{K2636B:2-ChB}Meas-Sel', name = 'measure_mode_2B')
-current_pulse_2B = EpicsSignal('XF:02IDD{K2636B:2-ChB}PIMV-CurrLevl', name = 'current_pulse_2B')
-time_pulse_2B = EpicsSignal('XF:02IDD{K2636B:2-ChB}PIMV-TOn', name = 'time_pulse_2B')
-interval_pulse_2B = EpicsSignal('XF:02IDD{K2636B:2-ChB}Cmd-Pulse.SCAN', name = 'interval_pulse_2B')
-voltage_pulse_rbk_2B = EpicsSignal('XF:02IDD{K2636B:2-ChB}Prev-Buf', name = 'voltage_pulse_rbk_2B')
+class Keithley2600BCurrentRamped(PVPositioner):
+    """PVPositioner for ramped Keithley 2600B current control (speed-controlled)."""
 
-#temperature_cryostat = EpicsSignal('XF:02IDD-ES{TCtrl:1-Chan:B}T-I', name = 'temperature_cryostat')
-#temperature_sample = EpicsSignal('XF:02IDD-ES{TCtrl:1-Chan:A}T-I', name = 'temperature_sample')
+    setpoint = Cpt(EpicsSignal, 'Val:SP-I_u')
+    readback = Cpt(EpicsSignalRO, 'RB-ILvl')
+    done = Cpt(EpicsSignalRO, 'DMOV-I')
+    done_value = 1
 
+
+class Keithley2600BChannel(Device):
+    """Ophyd device for Keithley 2600B Source Meter single channel."""
+
+    # ===== Identification =====
+    identity = Cpt(EpicsSignalRO, 'Val:Idnt-I', kind=Kind.config)
+
+    # ===== Output Control =====
+    output_enable = Cpt(EpicsSignal, 'Cmd:Out-Ena', kind=Kind.config)
+    output_status = Cpt(EpicsSignalRO, 'Sts:Out-Ena', kind=Kind.normal)
+    abort = Cpt(EpicsSignal, 'Cmd:Abort', kind=Kind.omitted)
+
+    # ===== Source Function =====
+    source_select = Cpt(EpicsSignal, 'Sour-Sel', kind=Kind.config)
+    source_status = Cpt(EpicsSignalRO, 'Sour:Sts', kind=Kind.normal)
+
+    # ===== Voltage Control =====
+    # Direct (immediate) control
+    voltage = Cpt(Keithley2600BVoltage, '')
+    # Ramped (speed-controlled) control
+    voltage_ramped = Cpt(Keithley2600BVoltageRamped, '')
+    voltage_ramp_speed = Cpt(EpicsSignal, 'Speed-E', kind=Kind.config)
+    voltage_ramp_stop = Cpt(EpicsSignal, 'STOP-E', kind=Kind.omitted)
+    voltage_limit_setpoint = Cpt(EpicsSignal, 'SP-LimV', kind=Kind.config)
+    voltage_limit_readback = Cpt(EpicsSignalRO, 'RB-LimV', kind=Kind.config)
+
+    # ===== Current Control =====
+    # Direct (immediate) control
+    current = Cpt(Keithley2600BCurrent, '')
+    # Ramped (speed-controlled) control
+    current_ramped = Cpt(Keithley2600BCurrentRamped, '')
+    current_ramp_speed = Cpt(EpicsSignal, 'Speed-I', kind=Kind.config)
+    current_ramp_stop = Cpt(EpicsSignal, 'STOP-I', kind=Kind.omitted)
+    current_limit_setpoint = Cpt(EpicsSignal, 'SP-LimI', kind=Kind.config)
+    current_limit_readback = Cpt(EpicsSignalRO, 'RB-LimI', kind=Kind.config)
+
+    # ===== Measurement Readbacks =====
+    measure_mode = Cpt(EpicsSignal, 'Meas-Sel', kind=Kind.config)
+    measured_voltage = Cpt(EpicsSignalRO, 'RB-MeasV', kind=Kind.hinted)
+    measured_current = Cpt(EpicsSignalRO, 'RB-MeasI', kind=Kind.hinted)
+    measured_resistance = Cpt(EpicsSignalRO, 'RB-MeasR', kind=Kind.normal)
+    measured_power = Cpt(EpicsSignalRO, 'RB-MeasP', kind=Kind.normal)
+
+    # ===== Source Auto Range =====
+    source_auto_range_voltage_sp = Cpt(EpicsSignal, 'SP-SourAutoRangV', kind=Kind.config)
+    source_auto_range_voltage_sts = Cpt(EpicsSignalRO, 'Sts:SourAutoRangV', kind=Kind.config)
+    source_auto_range_current_sp = Cpt(EpicsSignal, 'SP-SourAutoRangI', kind=Kind.config)
+    source_auto_range_current_sts = Cpt(EpicsSignalRO, 'Sts:SourAutoRangI', kind=Kind.config)
+
+    # ===== Measure Auto Range =====
+    meas_auto_range_voltage_sp = Cpt(EpicsSignal, 'SP-MeasAutoRangV', kind=Kind.config)
+    meas_auto_range_voltage_sts = Cpt(EpicsSignalRO, 'Sts:MeasAutoRangV', kind=Kind.config)
+    meas_auto_range_current_sp = Cpt(EpicsSignal, 'SP-MeasAutoRangI', kind=Kind.config)
+    meas_auto_range_current_sts = Cpt(EpicsSignalRO, 'Sts:MeasAutoRangI', kind=Kind.config)
+
+    # ===== Source Range =====
+    source_range_voltage_sp = Cpt(EpicsSignal, 'SP-SourVRang', kind=Kind.config)
+    source_range_voltage_sts = Cpt(EpicsSignalRO, 'Sts-SourVRang', kind=Kind.config)
+    source_range_current_sp = Cpt(EpicsSignal, 'SP-SourIRang', kind=Kind.config)
+    source_range_current_sts = Cpt(EpicsSignalRO, 'Sts-SourIRang', kind=Kind.config)
+
+    # ===== Measure Range =====
+    meas_range_voltage_sp = Cpt(EpicsSignal, 'SP-MeasVRang', kind=Kind.config)
+    meas_range_voltage_sts = Cpt(EpicsSignalRO, 'Sts-MeasVRang', kind=Kind.config)
+    meas_range_current_sp = Cpt(EpicsSignal, 'SP-MeasIRang', kind=Kind.config)
+    meas_range_current_sts = Cpt(EpicsSignalRO, 'Sts-MeasIRang', kind=Kind.config)
+
+    # ===== Pulse Configuration =====
+    pulse_current_bias = Cpt(EpicsSignal, 'PIMV-CurrBias', kind=Kind.config)
+    pulse_current_level = Cpt(EpicsSignal, 'PIMV-CurrLevl', kind=Kind.config)
+    pulse_voltage_limit = Cpt(EpicsSignal, 'PIMV-VLim', kind=Kind.config)
+    pulse_time_on = Cpt(EpicsSignal, 'PIMV-TOn', kind=Kind.config)
+    pulse_time_off = Cpt(EpicsSignal, 'PIMV-TOff', kind=Kind.config)
+    pulse_count = Cpt(EpicsSignal, 'PIMV-NPuls', kind=Kind.config)
+    configure_pulse_current = Cpt(EpicsSignal, 'Conf-PulseI', kind=Kind.omitted)
+    configure_pulse_current_status = Cpt(EpicsSignalRO, 'Conf-PulseI-Sts', kind=Kind.omitted)
+    configure_pulse_voltage = Cpt(EpicsSignalRO, 'Conf-PulseV', kind=Kind.omitted)
+    run_pulse = Cpt(EpicsSignalRO, 'Cmd-Pulse', kind=Kind.omitted)
+    pulse_buffer = Cpt(EpicsSignalRO, 'Prev-Buf', kind=Kind.normal)
+
+    # ===== Test Commands =====
+    load_beep_test = Cpt(EpicsSignal, 'Cmd:LoadBeepTest', kind=Kind.omitted)
+    run_beep_test = Cpt(EpicsSignal, 'Cmd:BeepTest', kind=Kind.omitted)
+
+
+# Keithley 1 Channel A
+k2600b_1a = Keithley2600BChannel('XF:02IDD{K2636B:1-ChA}', name='k2600b_1a')
+
+# Keithley 1 Channel B
+k2600b_1b = Keithley2600BChannel('XF:02IDD{K2636B:1-ChB}', name='k2600b_1b')
+
+# Keithley 2 Channel A
+k2600b_2a = Keithley2600BChannel('XF:02IDD{K2636B:2-ChA}', name='k2600b_2a')
+
+# Keithley 2 Channel B
+k2600b_2b = Keithley2600BChannel('XF:02IDD{K2636B:2-ChB}', name='k2600b_2b')

--- a/startup/96-keithley.py
+++ b/startup/96-keithley.py
@@ -66,6 +66,17 @@ class Keithley2600BCurrent(Keithley2600BPositionerMixin, PVPositionerPC):
     readback = Cpt(EpicsSignalRO, 'RB-ILvl')
 
 
+class Keithley2600BVoltageLimit(PVPositionerPC):
+    """PVPositioner for Keithley 2600B voltage limit control."""
+    setpoint = Cpt(EpicsSignal, 'SP-LimV')
+    readback = Cpt(EpicsSignalRO, 'RB-LimV')
+
+
+class Keithley2600BCurrentLimit(PVPositionerPC):
+    """PVPositioner for Keithley 2600B current limit control."""
+    setpoint = Cpt(EpicsSignal, 'SP-LimI')
+    readback = Cpt(EpicsSignalRO, 'RB-LimI')
+
 
 class Keithley2600BChannel(Device):
     """Ophyd device for Keithley 2600B Source Meter single channel."""
@@ -83,16 +94,12 @@ class Keithley2600BChannel(Device):
     source_status = Cpt(EpicsSignalRO, 'Sour:Sts', kind=Kind.normal)
 
     # ===== Voltage Control =====
-    # Direct (immediate) control
     voltage = Cpt(Keithley2600BVoltage, '')
-    voltage_limit_setpoint = Cpt(EpicsSignal, 'SP-LimV', kind=Kind.config)
-    voltage_limit_readback = Cpt(EpicsSignalRO, 'RB-LimV', kind=Kind.config)
+    voltage_limit = Cpt(Keithley2600BVoltageLimit, '')
 
     # ===== Current Control =====
-    # Direct (immediate) control
     current = Cpt(Keithley2600BCurrent, '')
-    current_limit_setpoint = Cpt(EpicsSignal, 'SP-LimI', kind=Kind.config)
-    current_limit_readback = Cpt(EpicsSignalRO, 'RB-LimI', kind=Kind.config)
+    current_limit = Cpt(Keithley2600BCurrentLimit, '')
 
     # ===== Measurement Readbacks =====
     measure_mode = Cpt(EpicsSignal, 'Meas-Sel', kind=Kind.config)

--- a/startup/96-keithley.py
+++ b/startup/96-keithley.py
@@ -149,13 +149,13 @@ class Keithley2600BChannel(Device):
 
 
 # Keithley 1 Channel A
-k2600b_1a = Keithley2600BChannel('XF:02IDD{K2636B:1-ChA}', name='k2600b_1a')
+k2636b_1a = Keithley2600BChannel('XF:02IDD{K2636B:1-ChA}', name='k2636b_1a')
 
 # Keithley 1 Channel B
-k2600b_1b = Keithley2600BChannel('XF:02IDD{K2636B:1-ChB}', name='k2600b_1b')
+k2636b_1b = Keithley2600BChannel('XF:02IDD{K2636B:1-ChB}', name='k2636b_1b')
 
 # Keithley 2 Channel A
-k2600b_2a = Keithley2600BChannel('XF:02IDD{K2636B:2-ChA}', name='k2600b_2a')
+k2636b_2a = Keithley2600BChannel('XF:02IDD{K2636B:2-ChA}', name='k2636b_2a')
 
 # Keithley 2 Channel B
-k2600b_2b = Keithley2600BChannel('XF:02IDD{K2636B:2-ChB}', name='k2600b_2b')
+k2636b_2b = Keithley2600BChannel('XF:02IDD{K2636B:2-ChB}', name='k2636b_2b')

--- a/startup/96-keithley.py
+++ b/startup/96-keithley.py
@@ -147,10 +147,6 @@ class Keithley2600BChannel(Device):
     run_pulse = Cpt(EpicsSignalRO, 'Cmd-Pulse', kind=Kind.omitted)
     pulse_buffer = Cpt(EpicsSignalRO, 'Prev-Buf', kind=Kind.normal)
 
-    # ===== Test Commands =====
-    load_beep_test = Cpt(EpicsSignal, 'Cmd:LoadBeepTest', kind=Kind.omitted)
-    run_beep_test = Cpt(EpicsSignal, 'Cmd:BeepTest', kind=Kind.omitted)
-
 
 # Keithley 1 Channel A
 k2600b_1a = Keithley2600BChannel('XF:02IDD{K2636B:1-ChA}', name='k2600b_1a')


### PR DESCRIPTION
Implements an ophyd device to control 2 Keithley devices with 2 channels each (total of 4 device instances).

Had to do some funky stuff with overriding the `move` to inject a dynamic `settle_time` based on another PV's scan field. This is how the measurement is done after a move.